### PR TITLE
add link to cryptonomica.net 

### DIFF
--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -43,6 +43,9 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Mutt](/software/mutt/)
 * [Thunderbird: Enigmail](/software/enigmail/)
 
+## Web
+* [Cryptonomica](https://cryptonomica.net/#!/openPGPOnline)
+
 ## Browser Plugins
 * [Mailvelope](/software/mailvelope/)
 * [FlowCrypt (Gmail)](https://flowcrypt.com/)


### PR DESCRIPTION
Cryptonomica OpenPGP online:  https://cryptonomica.net/#!/openPGPOnline