### PR TITLE
Add OpenPGP-PHP library.

### DIFF
--- a/_software/03-developer-tools.md
+++ b/_software/03-developer-tools.md
@@ -2,7 +2,7 @@
 title: "Developer Libraries/Tools"
 permalink: /software/developer/
 excerpt: "Developer Libraries/Tools"
-modified: 2016-08-15T15:00:00-00:00
+modified: 2018-12-22T00:32:11-00:00
 ---
 
 {% include base_path %}
@@ -26,6 +26,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
   (Objective C)
 * [OCaml PGP](https://github.com/cfcs/ocaml-openpgp) (OCaml)
 * [OpenKeychain API](https://github.com/open-keychain/openpgp-api) (Java)
+* [OpenPGP-PHP](https://github.com/singpolyma/openpgp-php) (PHP)
 * [OpenPGP.js](https://openpgpjs.org/) (Javascript)
 * [PGPy](https://github.com/SecurityInnovation/PGPy/) (Python)
 * [RNP](https://www.rnpgp.com/) (C++)


### PR DESCRIPTION
The OpenPGP-PHP library is a pure PHP implementation of RFC 4880 and can be used to implement OpenPGP-compatible software that can perform key generation, message encryption and decryption, message signing and verification, and so on entirely within PHP code. The library is currently used in the [WP PGP Encrypted Emails](https://wordpress.org/plugins/wp-pgp-encrypted-emails/) plugin for WordPress, which implements transparent OpenPGP message encryption and signing for all email messages generated by the WordPress core content management system and all its plugins. Both projects are under active development.