### PR TITLE
Update 01-software.md

### DIFF
--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -62,7 +62,7 @@ While these are easier to set up and provide basic security guarantees with Open
 
 * [Hushmail](https://www.hushmail.com/) (limited OpenPGP support)
 * [Mailfence](https://www.mailfence.com/)
-* [ProtonMail](https://protonmail.com/) (only incoming OpenPGP support)
+* [ProtonMail](https://protonmail.com/)
 
 ## Project Missing?
 If a project is missing and you would like it included, please open a pull request at [github.com/OpenPGP/openpgp.org](https://github.com/OpenPGP/openpgp.org).


### PR DESCRIPTION
ProtonMail now has incoming and outgoing OpenPGP support.
https://protonmail.com/blog/address-verification-pgp-support/