### PR TITLE
Add OpenPGP Keyserver

### DIFF
--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -27,6 +27,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Nyms](http://nyms.io)
 * [SKS Keyserver](https://sks-keyservers.net) (in OCaml)
 * [Hockeypuck Keyserver](https://hockeypuck.github.io/) (in Go)
+* [OpenPGP Keyserver](https://keys.openpgp.org) (in Rust)
 
 ## Mailing List Software
 


### PR DESCRIPTION
When looking for the URL to the OpenPGP Keyserver, I was a bit surprised that I wasn't able to find it even after having found the domain for it.

While I think it could be even more prominent than this, since the Keyserver page is a bit hidden away and hard to find, this should be a pretty uncontroversial change.