### PR TITLE
Adding Thunderbird's Autocrypt extension

### DIFF
--- a/_software/01-17-autocrypt.md
+++ b/_software/01-17-autocrypt.md
@@ -1,0 +1,16 @@
+---
+title: "Autocrypt"
+permalink: /software/autocrypt/
+excerpt: "Email Encryption"
+modified: 2019-10-25T15:00:00-00:00
+---
+
+Autocrypt is an Add-On for Mozilla Thunderbird. It implements OpenPGP on a very user friendly way. Following the concepts of Autocrypt the user experience a full automated OpenPGP experience.
+
+
+### Key Facts
+
+* Developer/Publisher: [Valodim](https://addons.thunderbird.net/en-US/thunderbird/user/Valodim/)
+* License: Open Source (MPL)
+* Price: Free.
+* Web: [Get Autocrypt](https://addons.thunderbird.net/en-US/thunderbird/addon/autocrypt/)

--- a/_software/01-17-autocrypt.md
+++ b/_software/01-17-autocrypt.md
@@ -5,7 +5,7 @@ excerpt: "Email Encryption"
 modified: 2019-10-25T15:00:00-00:00
 ---
 
-Autocrypt is an Add-On for Mozilla Thunderbird. It implements OpenPGP on a very user friendly way. Following the concepts of Autocrypt the user experience a full automated OpenPGP experience.
+Autocrypt is an Add-On for Mozilla Thunderbird. It implements OpenPGP in a very user friendly manner. Following the concepts of Autocrypt the user experience a full automated OpenPGP experience.
 
 
 ### Key Facts

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -21,13 +21,17 @@ No security audits have been done by us and, thus, we cannot provide any securit
   * [gpg4o](/software/gpg4o/)
   * [Gpg4win](/software/gpg4win/)
   * [p≡p](/software/pep/)
-* [Thunderbird: Enigmail](/software/enigmail/)
+* Thunderbird:
+  * [Autocrypt](/software/autocrypt/)
+  * [Enigmail](/software/enigmail/)
 
 ## Mac OS
 * [Apple Mail: GPGTools](/software/gpgtools/)
 * [Canary Mail](/software/canary-mail/)
 * [Mutt](/software/mutt/)
-* [Thunderbird: Enigmail](/software/enigmail/)
+* Thunderbird:
+  * [Autocrypt](/software/autocrypt/)
+  * [Enigmail](/software/enigmail/)
 
 ## Android
 * [K-9 Mail: OpenKeychain](/software/openkeychain/)


### PR DESCRIPTION
Since 15 August Autocrypt has its own extension in Thunderbird. It implements the fork of the OpenPGP standard Autocrypt.