### PR TITLE
Add Claws Mail client

### DIFF
--- a/_software/01-19-claws.md
+++ b/_software/01-19-claws.md
@@ -1,0 +1,19 @@
+---
+title: "Claws Mail"
+permalink: /software/claws/
+excerpt: "Email Encryption"
+modified: 2020-03-07T23:05:00-00:00
+---
+
+Claws Mail is a lightweight and fast email client based on GTK+ for Linux and Windows. It contains a plugin to enable email signing and encryption using GnuPG / gpgme, implementing the OpenPGP standard.
+
+
+### Key Facts
+
+* Developer/Publisher: [Team](https://claws-mail.org/theteam.php) of dedicated developers, translators and contributors
+* License: Open Source (GPL)
+* Price: Free. [Donations](https://claws-mail.org/sponsors.php) welcome
+* Web: [https://claws-mail.org](https://claws-mail.org)
+* Help: Help is provided on their website
+	* [User Manual](https://claws-mail.org/documentation.php)
+	* [FAQ](https://claws-mail.org/faq/index.php/Main_Page)

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -14,6 +14,7 @@ The authors of this webpage are not actively participating in the development of
 No security audits have been done by us and, thus, we cannot provide any security guarantees.
 
 ## Windows
+* [Claws Mail](/software/claws/)
 * [eM Client](/software/emclient/)
 * [EverDesk](/software/everdesk/)
 * [The Bat!](/software/thebat/)
@@ -44,6 +45,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [iPGMail](/software/ipgmail/)
 
 ## Linux
+* [Claws Mail](/software/claws/)
 * [Evolution: Seahorse](/software/seahorse/)
 * [KMail: Kleopatra](/software/kleopatra/)
 * [Mutt](/software/mutt/)


### PR DESCRIPTION
Signed-off-by: Bernd Waibel <waebbl@gmail.com>

I was missing the Claws Mail client (fork of Sylpheed Claws), a GTK+ based mail client for Linux and Windows. I know only the Linux client, but according to their site, the Windows client also support the encryption plugin using GPG4win.
