### PR TITLE
Add Postbox Email

### DIFF
--- a/_software/01-04-enigmail.md
+++ b/_software/01-04-enigmail.md
@@ -2,10 +2,10 @@
 title: "Enigmail"
 permalink: /software/enigmail/
 excerpt: "Email Encryption"
-modified: 2016-10-25T15:00:00-00:00
+modified: 2020-04-17T21:40:00-00:00
 ---
 
-Enigmail is an Add-On for Mozilla Thunderbird. With GnuPG, it implements the OpenPGP standard. The product enables email encryption and signing directly into Thunderbird. The focus is on an easy interface for email security. 
+Enigmail is an Add-On for Postbox and Mozilla Thunderbird. With GnuPG, it implements the OpenPGP standard. The product enables email encryption and signing directly into Postbox and Thunderbird. The focus is on an easy interface for email security. 
 
 
 ### Key Facts

--- a/_software/01-20-postbox.md
+++ b/_software/01-20-postbox.md
@@ -1,0 +1,21 @@
+---
+title: "Postbox"
+permalink: /software/postbox/
+excerpt: "Email Encryption"
+modified: 2020-04-17T21:40:00-00:00
+---
+
+Postbox for macOS and Windows is a power email app that has the ease of use of Apple Mail, but with more features and configuration options to handle high-volume workloads. [Enigmail](/software/enigmail/) for Postbox, an add-on that uses GnuPG to implement the OpenPGP standard, enables email encryption and signing directly within the app.
+
+### Key Facts
+
+* Developer/Publisher: Postbox, Inc.
+* License: Proprietary (Closed Source)
+* Encryption Library: OpenPGP (Open Source)
+* Price:
+	* 1-Year License: $29.00
+	* Lifetime License: $59.00
+* Web: [https://postbox-inc.com](https://postbox-inc.com)
+* Help:
+	* [Documentation and Help Center](https://support.postbox-inc.com/hc/en-us)
+	* [Twitter](https://twitter.com/Postbox)

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -2,7 +2,7 @@
 title: "Email Encryption"
 permalink: /software/
 excerpt: "Email Encryption"
-modified: 2018-02-08T09:00:00-00:00
+modified: 2020-04-17T21:40:00-00:00
 ---
 
 {% include base_path %}
@@ -22,6 +22,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
   * [gpg4o](/software/gpg4o/)
   * [Gpg4win](/software/gpg4win/)
   * [p≡p](/software/pep/)
+* [Postbox](/software/postbox/) using [Enigmail](/software/enigmail/)
 * Thunderbird:
   * [Autocrypt](/software/autocrypt/)
   * [Enigmail](/software/enigmail/)
@@ -30,6 +31,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Apple Mail: GPGTools](/software/gpgtools/)
 * [Canary Mail](/software/canary-mail/)
 * [Mutt](/software/mutt/)
+* [Postbox](/software/postbox/) using [Enigmail](/software/enigmail/)
 * Thunderbird:
   * [Autocrypt](/software/autocrypt/)
   * [Enigmail](/software/enigmail/)


### PR DESCRIPTION
Hi Gang, can we please add Postbox to the product pages? We use Enigmail and work directly with its developer to ensure compatibility.

We've listed Postbox before Thunderbird to adhere to your alphabetical listing scheme.

Thanks and let us know if you have any questions or require any additional information.

We've been in business for 12 years and our website is https://www.postbox-inc.com