### PR TITLE
Update 01-software.md

### DIFF
--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -39,6 +39,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 ## Android
 * [FairEmail](/software/fairemail/)
 * [K-9 Mail: OpenKeychain](/software/openkeychain/)
+* [neutriNote](https://play.google.com/store/apps/details?id=com.appmindlab.nano)
 * [p≡p](/software/pep/)
 * [R2Mail2](/software/r2mail2/)
 


### PR DESCRIPTION
Added the link to neutriNote for Android, a note taking app which supports encryption/decryption via OpenPGP.