### PR TITLE
Added Stalwart Mail Server as well as the Encryption at rest section.

### DIFF
--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -19,6 +19,10 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Pixelated](https://pixelated-project.org)
 * [Roundcube](https://roundcube.net/)
 
+## Encryption at Rest with OpenPGP
+
+* [Stalwart Mail Server](https://github.com/stalwartlabs/mail-server) (in Rust) ([documentation](https://stalw.art/docs/storage/encryption/pgp))
+
 ## Keyservers
 
 * [FlowCrypt Attester](https://flowcrypt.com/attester/)
@@ -29,6 +33,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
   the [LEAP](https://leap.se/) project
 * [Nyms](http://nyms.io)
 * [SKS Keyserver](https://sks-keyservers.net) (in OCaml)
+
 
 ## Mailing List Software
 


### PR DESCRIPTION
Hi,

I would like to add Stalwart Mail Server as well as the Encryption at Rest section. I added a new category as there were no "Mail Server" section on the website. Please feel free to rename it.

Stalwart Mail Server uses OpenPGP to automatically encrypt plain text messages using a user provided key.

Thank you.