### PR TITLE
Remove rotted "GitHub Page" from GPGFrontend page.

### DIFF
--- a/_software/04-01-gpgfrontend.md
+++ b/_software/04-01-gpgfrontend.md
@@ -23,7 +23,6 @@ Features:
 * License: Open Source (GNU GPL-3.0)
 * Price: Free.
 * Web:
-  * [GitHub Page](https://saturneric.github.io/GpgFrontend/index.html#/)
   * [GitHub Repository](https://github.com/saturneric/GpgFrontend)
 * Help: Help is provided in the README.md and by the developer via email
 	* [README.md](https://github.com/saturneric/GpgFrontend/blob/main/README.md)


### PR DESCRIPTION
This serves as a fix to issue #90. The current maintainer of GPGFrontend, saturneric, no longer has a valid github.io, which the “GitHub Page” link pointed to. There doesn't appear to be any suitable replacements for the rotted link, so I believe that omitting it is the best course of action.