### PR TITLE
Add mailbox.org to webmails

### DIFF
--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -105,6 +105,7 @@ While these are easier to set up and provide basic security guarantees with Open
 * [Mailfence](https://www.mailfence.com/)
 * [postale.io](https://postale.io/)
 * [ProtonMail](https://protonmail.com/)
+* [mailbox.org](https://mailbox.org/)
 
 ## Project Missing?
 


### PR DESCRIPTION
mailbox.org allows mail encryption in their webmail client.

https://kb.mailbox.org/en/private/e-mail-article/send-encrypted-e-mails-with-guard