### PR TITLE
Update 01-02-gpg4win.md

### DIFF
--- a/_software/01-02-gpg4win.md
+++ b/_software/01-02-gpg4win.md
@@ -2,7 +2,7 @@
 title: "Gpg4win"
 permalink: /software/gpg4win/
 excerpt: "Email Encryption"
-modified: 2016-10-25T15:00:00-00:00
+modified: 2025-05-25T00:00:00-00:00
 ---
 
 Gpg4win initiative does not only offer email encryption but a whole suite of tools. It can also be used for file encryption directly in the file explorer. Gpg4win is also the official distribution of GnuPG for Windows. The international initiative wants to focus on the builder to easily create updated installers for GnuPG.
@@ -11,9 +11,9 @@ Gpg4win initiative does not only offer email encryption but a whole suite of too
 
 * Developer/Publisher: Community
 * License: Open Source (GNU GPL)
-* Price: All tools are free of charge. [Donations](https://www.gpg4win.de/donate.html) are desired.
-* Web: [https://www.gpg4win.de/index.html](https://www.gpg4win.de/index.html)
+* Price: All tools are free of charge. [Donations](https://gpg4win.org/donate.html) are desired.
+* Web: [https://GPG4Win.org](https://gpg4win.org)
 * Help: Help is given through the communities
-	* [Support](https://www.gpg4win.de/community.html)
+	* [Support](https://gpg4win.org/community.html)
 	* [Forum](http://wald.intevation.org/forum/forum.php?forum_id=21)
 	

--- a/_software/01-02-gpg4win.md
+++ b/_software/01-02-gpg4win.md
@@ -2,7 +2,6 @@
 title: "Gpg4win"
 permalink: /software/gpg4win/
 excerpt: "Email Encryption"
-modified: 2025-05-25T00:00:00-00:00
 ---
 
 Gpg4win initiative does not only offer email encryption but a whole suite of tools. It can also be used for file encryption directly in the file explorer. Gpg4win is also the official distribution of GnuPG for Windows. The international initiative wants to focus on the builder to easily create updated installers for GnuPG.


### PR DESCRIPTION
Greetings, I noticed that the links for GPG4WIN have the .de domain, when the current is .org. So I changed the GPG4Win website links to the .org URL's. Also the double U's are not necessary anymore (www). At least for most websites.

Thank you, Shalom.